### PR TITLE
Switch to frontside.com domain

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "version": "0.0.1",
   "description": "Frontside Typescript Config",
   "repository": "https://github.com/frontside/tsconfig.git",
-  "author": "Frontside Engineering <engineering@frontside.io>",
+  "author": "Frontside Engineering <engineering@frontside.com>",
   "main": "tsconfig.json",
   "files": [
     "tsconfig.json"


### PR DESCRIPTION
`frontside.io` ➡️ `frontside.com`